### PR TITLE
BOPE-127 Tratar e-mail no plugin Magento antes de dar identify

### DIFF
--- a/app/code/local/Dito/DitoTracking/Helper/Data.php
+++ b/app/code/local/Dito/DitoTracking/Helper/Data.php
@@ -40,14 +40,15 @@ class Dito_DitoTracking_Helper_Data extends Mage_Core_Helper_Abstract {
       }
 
       $phone = isset($phoneFromConfig) ? $phoneFromConfig : $phoneFromAddress;
+      $email = preg_replace('/\s*/', '', strtolower($customer->getEmail());
 
       if($customer->getDob()){
         $birthday = split(' ', $customer->getDob())[0];
       }
 
       $user = Array(
-        'id' => sha1($customer->getEmail()),
-        'email' => $customer->getEmail(),
+        'id' => sha1($email),
+        'email' => $email,
         'name' => $customer->getName(),
         'birthday' => $birthday,
         'gender' => array('', 'male', 'female')[$customer->getGender()],


### PR DESCRIPTION
# Contexto
Antes de enviar o usuário para a Dito, é preciso garantir que o e-mail utilizado na geração do id do usuário esteja sempre em minúsculo e sem espaços em branco.