### PR TITLE
BOPE-296 - add track newsletter

### DIFF
--- a/app/code/local/Dito/DitoTracking/Helper/Data.php
+++ b/app/code/local/Dito/DitoTracking/Helper/Data.php
@@ -20,6 +20,14 @@ class Dito_DitoTracking_Helper_Data extends Mage_Core_Helper_Abstract {
     return Mage::getStoreConfig('ditotracking_options/cache_config/cache_strategy', $store);
   }
 
+  public function getNewsEnabled($store = null){
+    return Mage::getStoreConfig('ditotracking_options/track_newsletter/dito_newsletter_enabled', $store);
+  }
+
+  public function getNewsDataConfig($key, $store = null){
+    return Mage::getStoreConfig('ditotracking_options/track_newsletter/' . $key, $store);
+  }
+
   public function getUserIdentifyObject($customer){
     $user = Array();
 

--- a/app/code/local/Dito/DitoTracking/etc/system.xml
+++ b/app/code/local/Dito/DitoTracking/etc/system.xml
@@ -145,10 +145,58 @@
           </fields>
         </track_config>
 
+        <track_newsletter translate="label">
+          <label>Newsletter</label>
+          <frontend_type>text</frontend_type>
+          <sort_order>3</sort_order>
+          <show_in_default>1</show_in_default>
+          <show_in_website>1</show_in_website>
+          <show_in_store>1</show_in_store>
+
+          <fields>
+            <dito_newsletter_enabled>
+              <label>Habilitar Newsletter</label>
+              <frontend_type>select</frontend_type>
+              <source_model>adminhtml/system_config_source_yesno</source_model>
+              <sort_order>1</sort_order>
+              <show_in_default>1</show_in_default>
+              <show_in_website>1</show_in_website>
+              <show_in_store>1</show_in_store>
+            </dito_newsletter_enabled>
+
+            <name_selector>
+              <label>Seletor Nome</label>
+              <frontend_type>text</frontend_type>
+              <sort_order>2</sort_order>
+              <show_in_default>1</show_in_default>
+              <show_in_website>1</show_in_website>
+              <show_in_store>1</show_in_store>
+            </name_selector>
+
+            <email_selector>
+              <label>Seletor E-mail</label>
+              <frontend_type>text</frontend_type>
+              <sort_order>3</sort_order>
+              <show_in_default>1</show_in_default>
+              <show_in_website>1</show_in_website>
+              <show_in_store>1</show_in_store>
+            </email_selector>
+
+            <btn_selector>
+              <label>Seletor Botão</label>
+              <frontend_type>text</frontend_type>
+              <sort_order>4</sort_order>
+              <show_in_default>1</show_in_default>
+              <show_in_website>1</show_in_website>
+              <show_in_store>1</show_in_store>
+            </btn_selector>
+          </fields>
+        </track_newsletter>
+
         <user_config translate="label">
           <label>Usuários</label>
           <frontend_type>text</frontend_type>
-          <sort_order>3</sort_order>
+          <sort_order>4</sort_order>
           <show_in_default>1</show_in_default>
           <show_in_website>1</show_in_website>
           <show_in_store>1</show_in_store>
@@ -187,7 +235,7 @@
         <cache_config translate="label">
           <label>Cache</label>
           <frontend_type>text</frontend_type>
-          <sort_order>4</sort_order>
+          <sort_order>5</sort_order>
           <show_in_default>1</show_in_default>
           <show_in_website>1</show_in_website>
           <show_in_store>1</show_in_store>

--- a/app/design/frontend/base/default/layout/ditotracking.xml
+++ b/app/design/frontend/base/default/layout/ditotracking.xml
@@ -8,6 +8,9 @@
         <block type="core/template" name="ditotracking.alias" template="ditotracking/alias.phtml" />
       </reference>
     </reference>
+    <reference name="content">
+      <block type="core/template" name="ditotracking.newsletter" template="ditotracking/newsletter.phtml" />
+    </reference>
   </default>
 
   <catalogsearch_result_index>

--- a/app/design/frontend/base/default/template/ditotracking/newsletter.phtml
+++ b/app/design/frontend/base/default/template/ditotracking/newsletter.phtml
@@ -1,0 +1,42 @@
+<?php $helper = Mage::helper('ditotracking'); ?>
+
+<?php if($helper->getNewsEnabled()): ?>
+  <?php 
+    $nameSelector = $helper->getNewsDataConfig('name_selector');
+    $emailSelector = $helper->getNewsDataConfig('email_selector');
+    $btnSelector = $helper->getNewsDataConfig('btn_selector');
+  ?>
+
+  <script type="text/javascript">
+    (function(){
+      var nameSelector = '<?php echo $nameSelector; ?>';
+      var emailSelector = '<?php echo $emailSelector; ?>';
+      var clickSelector = '<?php echo $btnSelector; ?>';
+      var filter = /^([a-zA-Z0-9_\.\-])+\@(([a-zA-Z0-9\-])+\.)+([a-zA-Z0-9]{2,4})+$/;
+
+      var identify = function(email, name) {
+        return dito.identify({
+          id: dito.generateID(email),
+          name: name,
+          email: email,
+          data: {
+            origem_cadastro: 'newsletter'
+          }
+        });
+      };
+
+      if(!clickSelector) return;
+
+      jQuery(document).on('click', clickSelector, function (event) {
+        var email = jQuery(emailSelector).val();
+        var name = jQuery(nameSelector).val();
+
+        if(email == null || email == '' || !filter.test(email) ) {
+          return;
+        }
+
+        identify(email, name);
+      });
+    }());
+  </script>
+<?php endif; ?>

--- a/app/design/frontend/base/default/template/ditotracking/newsletter.phtml
+++ b/app/design/frontend/base/default/template/ditotracking/newsletter.phtml
@@ -12,7 +12,7 @@
       var nameSelector = '<?php echo $nameSelector; ?>';
       var emailSelector = '<?php echo $emailSelector; ?>';
       var clickSelector = '<?php echo $btnSelector; ?>';
-      var filter = /^([a-zA-Z0-9_\.\-])+\@(([a-zA-Z0-9\-])+\.)+([a-zA-Z0-9]{2,4})+$/;
+      var filter = /^([a-zA-Z0-9_\-\.+]+)@([a-zA-Z0-9_\-\.]+)\.([a-zA-Z]{2,5})$/;
 
       var identify = function(email, name) {
         return dito.identify({

--- a/app/design/frontend/base/default/template/ditotracking/newsletter.phtml
+++ b/app/design/frontend/base/default/template/ditotracking/newsletter.phtml
@@ -15,6 +15,11 @@
       var filter = /^([a-zA-Z0-9_\-\.+]+)@([a-zA-Z0-9_\-\.]+)\.([a-zA-Z]{2,5})$/;
 
       var identify = function(email, name) {
+
+        if(email == null || email == '' || !filter.test(email) ) {
+          return;
+        }
+
         return dito.identify({
           id: dito.generateID(email),
           name: name,
@@ -30,10 +35,6 @@
       jQuery(document).on('click', clickSelector, function (event) {
         var email = jQuery(emailSelector).val();
         var name = jQuery(nameSelector).val();
-
-        if(email == null || email == '' || !filter.test(email) ) {
-          return;
-        }
 
         identify(email, name);
       });


### PR DESCRIPTION
## Contexto

O plugin Magento Dito, não tem suporte de identify em newsletter. Esse PR implementa essa  funcionalidade.

## Para testar
Fazer a instalação do Magento via docker. [repo](https://github.com/andreaskoch/dockerized-magento)

1. Fazer a instalação do plugin
2. Habilitar o campos necessários e configurar os seletores da news
3. Verificar o funcionamento do track na newsletter

Preview da tela:

![screen shot 2018-03-26 at 7 28 47 pm](https://user-images.githubusercontent.com/3994865/37936458-00dd2a60-312c-11e8-924a-9dd36f80d7bc.png)
